### PR TITLE
remove node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "puppeteer": "^1.20.0",
     "spotify-web-api-node": "^4.0.0"
   },
-  "engines": {
-    "node": "8.x"
-  },
   "repository": {
     "url": "https://glitch.com/edit/#!/hello-express"
   },


### PR DESCRIPTION
### Motivation
Beanstalk doesn't accept Node 8 as an engine. We don't need to specify the engine as any node install will use it's own unless we say otherwise with this setting.

```
[ERROR] An error occurred during execution of command [app-deploy] - [Install customer specified node.js version]. Stop running the command. Error: unsupported node version 8.x, please specify any of node versions in [v12.0.0 v12.1.0 v12.10.0 v12.11.0 v12.11.1 v12.12.0 v12.13.0 v12.13.1 v12.14.0 v12.14.1 v12.15.0 v12.16.0 v12.16.1 v12.16.2 v12.16.3 v12.17.0 v12.18.0 v12.18.1 v12.2.0 v12.3.0 v12.3.1 v12.4.0 v12.5.0 v12.6.0 v12.7.0 v12.8.0 v12.8.1 v12.9.0 v12.9.1] 
```
