### PR TITLE
Chore: Update request and response structure for GET /track/audio-features

### DIFF
--- a/helpers/spotify.js
+++ b/helpers/spotify.js
@@ -124,12 +124,24 @@ const setPlaylistCover = async (id, image) => {
 };
 
 /**
+ * @description sanitizes the response for spotify's get audio track features API
+ * @param {Object|null} data The data to be sanitized
+ * @returns {Object} the sanitized audio features for a track
+ */
+const sanitizeGetAudioFeaturesForTrackResponse = (data) => {
+  if (!data) return {};
+  const { duration_ms: durationMs, ...dataWithoutDurationInMs } = data;
+  return { ...dataWithoutDurationInMs, duration: durationMs / 1000 };
+};
+
+/**
  * @description returns the features for a single track
  * @param {String} tracks A single track URL (string)
  * @returns {Promise<Object>} The audio features for a track
  */
 const getAudioFeaturesForTrack = (trackID) => spotifyApi.getAudioFeaturesForTrack(trackID)
-  .then((response) => response.body);
+  .then((response) => sanitizeGetAudioFeaturesForTrackResponse(response.body));
+
 /**
  * @description confirms that a URL is a Spotify URL
  * @param {String} trackURL the URL to be checked

--- a/server.js
+++ b/server.js
@@ -145,25 +145,18 @@ app.get('/covers', (req, res) => {
   res.sendFile(path.join(`${__dirname}/views/covers.html`));
 });
 
-app.get('/track/audio-features', async (req, res) => {
+app.get('/track/:id/audio-features', async (req, res) => {
   try {
-    const { spotify_link: spotifyLink } = req.query;
-    if (!spotifyLink) {
+    const { id: trackId } = req.params;
+    if (!trackId) {
       return res.status(400).send({
         status: false,
-        message: '"spotify_link" is required',
-      });
-    }
-    if (!spotify.isSpotifyTrack(spotifyLink)) {
-      return res.status(400).send({
-        status: false,
-        message: 'Spotify link is invalid',
+        message: '"track_id" is required',
       });
     }
 
     await spotify.performAuthentication();
-    const { trackId: spotifyID } = spotify.getSpotifyUrlParts(spotifyLink);
-    const trackFeatures = await spotify.getAudioFeaturesForTrack(spotifyID);
+    const trackFeatures = await spotify.getAudioFeaturesForTrack(trackId);
     return res.status(200).send({
       status: true,
       data: trackFeatures,


### PR DESCRIPTION
### Changes
- Changed the request structure of endpoint to fetch audio features for a track from `GET /track/audio-features` => `GET /track/:id/audio-features`

- Updated the response from the `GET /track/:id/audio-features` to return track duration in seconds