### PR TITLE
remove contributors and track information from GET /playlists response

### DIFF
--- a/helpers/spotify.js
+++ b/helpers/spotify.js
@@ -206,6 +206,7 @@ const savePlaylist = async (playlistData, contributors) => {
     name: playlistData.name,
     description: playlistData.description,
     playlist_url: playlistData.external_urls.spotify,
+    playlist_uri: `spotify:playlist:${playlistData.id}`,
     spotifyId: playlistData.id,
     date_added: playlistData.date_added,
     contributors: contributorIds,
@@ -278,7 +279,7 @@ const findPlaylist = async (playlistId) => {
     profile_image: 1,
   };
   return Playlist.findById(playlistId)
-    .select({ name: 1, description: 1, playlist_url: 1, hex: 1 })
+    .select({ name: 1, description: 1, playlist_url: 1, playlist_uri: 1, hex: 1 })
     .populate({
       path: 'tracks',
       select: {
@@ -307,34 +308,7 @@ const findPlaylist = async (playlistId) => {
  * @returns {Promise<Array>} The playlist data for multiple playlists
  */
 const findAllPlaylists = async () => {
-  const contributorFields = {
-    _id: 1,
-    name: 1,
-    about: 1,
-    profile_image: 1,
-  };
-  return Playlist.find({}, { name: 1, description: 1, playlist_url: 1, hex: 1 }, {})
-  .sort({date_added: -1})
-  .populate({
-    path: 'tracks',
-    select: {
-      _id: 1,
-      service: 1,
-      title: 1,
-      track_url: 1,
-      trackId: 1,
-      analytics: 1,
-    },
-    populate: {
-      path: 'contributors',
-      model: 'Contributor',
-      select: contributorFields,
-    },
-})
-.populate({
-  path: 'contributors',
-  model: 'Contributor',
-}).exec();
+  return Playlist.find({}, { name: 1, description: 1, playlist_url: 1, playlist_uri: 1, hex: 1 }, {});
 }
 
 module.exports = {

--- a/models/playlist.js
+++ b/models/playlist.js
@@ -4,6 +4,7 @@ const playlistSchema = new mongoose.Schema({
   name: String,
   description: String,
   playlist_url: String,
+  playlist_uri: String,
   spotifyId: String,
   hex: String,
   date_added: Date,


### PR DESCRIPTION
This PR:
- removes the contributors and tracks array from the `GET /playlists` response based on the request of the FE team.
- adds a `spotify_uri` to the playlist response.

Response object for `GET /playlists`

```
{
    "status": true,
    "data": [
        {
            "_id": "5f2f22986b717094457dd1d7",
            "name": "July 2020",
            "description": null,
            "playlist_url": "https://open.spotify.com/playlist/2h23OHmBvoNvqeiogvVKXt",
            "playlist_uri": "spotify:playlist:2h23OHmBvoNvqeiogvVKXt",
            "hex": "#251f23"
        },
        {
            "_id": "5f2f229b6b717094457dd285",
            "name": "June 2020",
            "description": null,
            "playlist_url": "https://open.spotify.com/playlist/5NdWthSpz9LO3bo3njgKHo",
            "playlist_uri": "spotify:playlist:5NdWthSpz9LO3bo3njgKHo",
            "hex": "#281c18"
        }
    ]
}
```
