### PR TITLE
Bugfix: Track title, not name

### DIFF
--- a/helpers/spotify.js
+++ b/helpers/spotify.js
@@ -260,7 +260,7 @@ const saveTracks = async (tracksData, playlist) => {
 
     return {
       service: track.service,
-      title: track.title,
+      title: track.name,
       track_url: track.link,
       trackId: track.id,
       contributors: contributorIds,


### PR DESCRIPTION
### Changes

Small error where we're referencing a non-existent property for track name.