### PR TITLE
disable x-powered-by

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { validate: validateRequest } = require('../validation/validate');
 const validationSchemas = require('../validation/schema');
 
-const router = express();
+const router = express.Router();
 
 const controllers = require('../controllers');
 

--- a/routes/playlists.js
+++ b/routes/playlists.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express();
+const router = express.Router();
 
 const controllers = require('../controllers/playlist');
 

--- a/routes/track.js
+++ b/routes/track.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { validate: validateRequest } = require('../validation/validate');
 const validationSchemas = require('../validation/schema');
 
-const router = express();
+const router = express.Router();
 
 const controllers = require('../controllers/track');
 

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(helmet());
+app.disable('x-powered-by');
 
 app.use('/', indexRouter);
 app.use('/playlists', playlistRouter);


### PR DESCRIPTION
`helmet` is supposed to disable this by default, but because we weren't using actual express routers on the endpoints they were adding it to the response. 

Also added `app.disable('x-powered-by');` as a fail-safe.