### PR TITLE
Bugfix: Wrong Track URL reference + Wrong Order of Artist Names

### DIFF
--- a/helpers/spotify.js
+++ b/helpers/spotify.js
@@ -261,10 +261,11 @@ const saveTracks = async (tracksData, playlist) => {
     return {
       service: track.service,
       title: track.name,
-      track_url: track.link,
+      track_url: track.url,
       trackId: track.id,
       contributors: contributorIds,
       artists: artistIds,
+      artist_names: track.artist_names.join(', '),
       isExplicit: track.explicit,
     };
   }));
@@ -366,6 +367,7 @@ const findPlaylist = async (playlistId) => {
         preview_url: 1,
         trackId: 1,
         analytics: 1,
+        artist_names: 1,
       },
       populate: [
         {

--- a/models/track.js
+++ b/models/track.js
@@ -10,6 +10,7 @@ const trackSchema = new mongoose.Schema({
   isExplicit: Boolean,
   contributors: [{ type: mongoose.ObjectId, ref: 'Contributor' }],
   artists: [{ type: mongoose.ObjectId, ref: 'Artist' }],
+  artist_names: String,
   analytics: mongoose.Mixed,
 });
 const Track = mongoose.model('Track', trackSchema, 'tracks');


### PR DESCRIPTION
Changes

- Fix bug where the track_url is not being returned because a wrong property is being referenced. Changed `track.link` to `track.url`

- Fix bug where featured artists sometimes came before main artists. Did this by adding the new field `artist_names`, making sure not to alter the existing `artists` property.