### PR TITLE
Bug: Save tracks before updating Preview URLs and Analytics

### DIFF
--- a/controllers/track.js
+++ b/controllers/track.js
@@ -5,10 +5,10 @@ module.exports = {
 
   getTrackAudioFeatures: async (req, res) => {
     try {
-      const tracks = await spotify.findTracksWithoutAnalytics();
+      const tracks = await spotify.findTracksWithoutField('analytics');
       if (!tracks.length) return res.status(200).send({ status: true, message: 'All tracks have their analytics set' });
       await spotify.performAuthentication();
-      spotify.getAudioAnalyticsForTracks(tracks);
+      spotify.handleTracksUpdateWithAnalytics(tracks);
       return res.status(200).send({
         status: true,
         message: 'Populating analytics...',
@@ -21,10 +21,10 @@ module.exports = {
 
   populateTrackPreviews: async (req, res) => {
     try {
-      const tracks = await spotify.findTracksWithoutPreview();
+      const tracks = await spotify.findTracksWithoutField('preview_url');
       if (!tracks.length) return res.status(200).send({ status: true, message: 'All tracks have their previews set' });
       await spotify.performAuthentication();
-      await spotify.getPreviewUrlForTracks(tracks);
+      await spotify.handleTracksUpdateWithPreviewUrls(tracks);
       return res.status(200).send({
         status: true,
         message: 'Previews have been populated.',

--- a/helpers/server-methods.js
+++ b/helpers/server-methods.js
@@ -48,10 +48,11 @@ const trigger = async ({ day, month, year }) => {
   playlist.date_added = playlistMonth.utc().toDate();
   const savedPlaylist = await spotify.savePlaylist(playlist, contributors);
 
+  await spotify.saveTracks(tracks, savedPlaylist);
+
   await Promise.all([
-    spotify.saveTracks(tracks, savedPlaylist),
-    spotify.getAudioAnalyticsForTracks(tracks),
-    spotify.getPreviewUrlForTracks(tracks),
+    spotify.handleTracksUpdateWithAnalytics(tracks),
+    spotify.handleTracksUpdateWithPreviewUrls(tracks),
   ]);
 
   // and songs to playlist


### PR DESCRIPTION
### Changes

- Refactored functions (renamed + split) for clarity of purpose
- Moved action for saving tracks so it comes before the parallel execution block where the tracks are updated with their preview URLs and analytics.

### Motivation

- Tracks were being saved without analytics and preview URLs because the logic to save the tracks and to update them were running in parallel. The update requests depend on existing track records and in cases where the update queries get completed before the query to save the tracks, what happened was that new track records with just `analytics`, `preview_url` or both were created. 

